### PR TITLE
Matlab version 2018b support also documented in fmu_export.md

### DIFF
--- a/docs/fmu_export.md
+++ b/docs/fmu_export.md
@@ -71,7 +71,7 @@ It is recommended to set the `Tasking mode` to `SingleTasking`.
 ### Limitations and Trouble-Shooting
 
 - This version of the package supports 32- and 64-bit MATLAB releases
-from R2010a to R2018a.
+from R2010a to R2018b.
 
 - On Windows, the package supports Visual Studio 2008 (9.0) and later compilers as supported with the respective MATLAB releases.
 


### PR DESCRIPTION
Start page https://github.com/CATIA-Systems/FMIKit-Simulink notes compatibilty with Matlab 2018b, so this should also be updated in the "Limitations and Trouble-Shooting" section?