### PR TITLE
Adding missing grtfmi_generate_guid.m script to installer project

### DIFF
--- a/FMI Kit.prj
+++ b/FMI Kit.prj
@@ -81,6 +81,7 @@
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_cmake_default_generator.m</file>
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_exclude_variable.m</file>
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_find_cmake.m</file>
+      <file>${PROJECT_ROOT}\grtfmi\grtfmi_generate_guid.m</file>
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_make_rtw_hook.m</file>
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_selectcallback.m</file>
       <file>${PROJECT_ROOT}\grtfmi\grtfmi_xml_datetime.m</file>


### PR DESCRIPTION
This should fix the problem described in issue #80. The GUID was always specified to "0". Problem was that the ```grtfmi_generate_guid.m``` script was not included in the installer.