### PR TITLE
Add support for relative resource locations in FMU export

### DIFF
--- a/grtfmi/grtfmi_make_rtw_hook.m
+++ b/grtfmi/grtfmi_make_rtw_hook.m
@@ -55,11 +55,17 @@ switch hookMethod
         resources = regexp(strtrim(resources), '\s+', 'split');
         if ~all(cellfun(@isempty, resources))
             disp('### Copy resources')
+            mkdir(fullfile('FMUArchive', 'resources'))
+            [parent_dir, ~, ~] = fileparts(current_dir);
             for i = 1:numel(resources)
-                resource = resources{i};
+                if ~exist(resources{i})
+                    resource = fullfile(parent_dir, resources{i});
+                else
+                    resource = resources{i};
+                end
                 disp(['Copying ' resource ' to resources'])
                 if isfile(resource)
-                    copyfile(resources{i}, fullfile('FMUArchive', 'resources'));
+                    copyfile(resource, fullfile('FMUArchive', 'resources'));
                 else
                     [~, folder, ~] = fileparts(resource);
                     copyfile(resource, fullfile('FMUArchive', 'resources', folder));


### PR DESCRIPTION
When exporting a Simulink model to FMU it is possible to specify resource files/folders which should be packed with the FMU. This adds support for specifying resources with both relative and absolute paths.