### PR TITLE
Avoid warning about precision loss in fmi2SetReal by explicitly casting to REAL32_T

### DIFF
--- a/grtfmi/fmi2Functions.c
+++ b/grtfmi/fmi2Functions.c
@@ -301,7 +301,7 @@ fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nv
 			*((REAL64_T *)v.address) = value[i];
 			break;
 		case SS_SINGLE:
-			*((REAL32_T *)v.address) = value[i];
+			*((REAL32_T *)v.address) = (REAL32_T)value[i];
 			break;
 		default:
 			return fmi2Error;


### PR DESCRIPTION
 In fmi2SetReal, the compiler issues a warning, since a double is converted to a single, which causes precision loss. In this case, this is desired, so we should explicitly cast to REAL32_T.